### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,6 +1,7 @@
 ---
 name: Shellcheck
-
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   shellcheck:


### PR DESCRIPTION
Potential fix for [https://github.com/usma0118/dotfiles/security/code-scanning/2](https://github.com/usma0118/dotfiles/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level (applies to all jobs) to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow is for running Shellcheck, it only needs to read the repository contents. Therefore, we will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
