### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,6 +1,8 @@
 ---
 # .github/workflows/ansible-lint.yml
 name: ansible-lint
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/usma0118/dotfiles/security/code-scanning/1](https://github.com/usma0118/dotfiles/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key to restrict the `GITHUB_TOKEN` to the minimum required privileges. For this workflow, which only checks out code and runs a linter, only read access to repository contents is needed. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file (after the `name` and before `on`), so it applies to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
